### PR TITLE
Fix security scan utilities

### DIFF
--- a/resources/utils/awk-extract-image.awk
+++ b/resources/utils/awk-extract-image.awk
@@ -1,12 +1,18 @@
 #!/usr/bin/awk -f
 BEGIN{IGNORECASE=1}
-toupper($1)=="FROM"{
+
+function handleFrom(line,    parts, n, i, t, img, stg) {
+  n = split(line, parts, /[ \t]+/)
   count++
   img=""; stg=""
-  for(i=2;i<=NF;i++){
-    t=$i
+  for (i=2; i<=n; i++) {
+    t = parts[i]
+    if (t == "") continue
     if (t ~ /^--platform=/) continue
-    if (toupper(t)=="AS"){ if (i+1<=NF) stg=$(i+1); break }
+    if (toupper(t)=="AS") {
+      if (i+1<=n) stg=parts[i+1]
+      break
+    }
     if (img=="") img=t
   }
   if (stg!="") stages[tolower(stg)]=1
@@ -18,7 +24,18 @@ toupper($1)=="FROM"{
     last_any=img
   }
 }
+
+toupper($1)=="FROM"{
+  line = $0
+  while (line ~ /\\\s*$/) {
+    sub(/\\\s*$/, "", line)
+    if (getline nextLine <= 0) break
+    line = line " " nextLine
+  }
+  handleFrom(line)
+}
+
 END{
-  if (count<=1) print (first_external!=""?first_external:last_any);
-  else print (last_external!=""?last_external:last_any);
+  if (count<=1) print (first_external!=""?first_external:last_any)
+  else print (last_external!=""?last_external:last_any)
 }

--- a/src/org/jenkinsci/nodesec/ShellUtils.groovy
+++ b/src/org/jenkinsci/nodesec/ShellUtils.groovy
@@ -1,0 +1,21 @@
+package org.jenkinsci.nodesec
+
+import java.io.File
+
+class ShellUtils {
+  static String shellQuote(String value) {
+    if (!value) {
+      return "''"
+    }
+    String escaped = value.replace("'", "'\"'\"'")
+    return "'${escaped}'"
+  }
+
+  static String parentDir(String path) {
+    if (!path) {
+      return ''
+    }
+    String parent = new File(path).parent
+    return parent ?: ''
+  }
+}

--- a/vars/conftestDockerfile.groovy
+++ b/vars/conftestDockerfile.groovy
@@ -1,9 +1,18 @@
-def call(Map cfg = [:]) { runWithCatch('OPA Conftest') {
-  String out = cfg.output ?: 'report/opa-report.sarif'
-  String policyDir = cfg.policyDir ?: 'policy'
+import org.jenkinsci.nodesec.ShellUtils
+
+def call(Map cfg = [:]) {
+  runWithCatch('OPA Conftest') {
+    String out = cfg.output ?: 'report/opa-report.sarif'
+    String policyDir = cfg.policyDir ?: 'policy'
+    String dockerfile = cfg.dockerfile ?: 'Dockerfile'
+
+    String outputDir = ShellUtils.parentDir(out)
+    if (outputDir) {
+      sh "mkdir -p ${ShellUtils.shellQuote(outputDir)}"
+    }
+
     sh """
-      mkdir -p report
-      conftest test --parser dockerfile -p ${policyDir} Dockerfile --output sarif > ${out}
+      conftest test --parser dockerfile -p ${ShellUtils.shellQuote(policyDir)} ${ShellUtils.shellQuote(dockerfile)} --output sarif > ${ShellUtils.shellQuote(out)}
     """
   }
 }

--- a/vars/gitleaksScan.groovy
+++ b/vars/gitleaksScan.groovy
@@ -1,9 +1,19 @@
-def call(Map cfg = [:]) { runWithCatch('Gitleaks scan secret') {
-  sh '''
-    mkdir -p report
-    gitleaks detect --source . --redact \
-    --report-format json \
-    --gitleaks-ignore-path . \
-    --report-path report/gitleaks-report.json
-  '''
-} }
+import org.jenkinsci.nodesec.ShellUtils
+
+def call(Map cfg = [:]) {
+  runWithCatch('Gitleaks scan secret') {
+    String out = cfg.output ?: 'report/gitleaks-report.json'
+
+    String outputDir = ShellUtils.parentDir(out)
+    if (outputDir) {
+      sh "mkdir -p ${ShellUtils.shellQuote(outputDir)}"
+    }
+
+    sh """
+      gitleaks detect --source . --redact \\
+      --report-format json \\
+      --gitleaks-ignore-path . \\
+      --report-path ${ShellUtils.shellQuote(out)}
+    """
+  }
+}

--- a/vars/npmAudit.groovy
+++ b/vars/npmAudit.groovy
@@ -1,8 +1,16 @@
-def call(Map cfg = [:]) { runWithCatch('NPM Dependency Audit') {
-  String out = cfg.output ?: 'report/npm-audit-report.json'
+import org.jenkinsci.nodesec.ShellUtils
+
+def call(Map cfg = [:]) {
+  runWithCatch('NPM Dependency Audit') {
+    String out = cfg.output ?: 'report/npm-audit-report.json'
+
+    String outputDir = ShellUtils.parentDir(out)
+    if (outputDir) {
+      sh "mkdir -p ${ShellUtils.shellQuote(outputDir)}"
+    }
+
     sh """
-      mkdir -p report
-      npm audit --audit-level=high --json > ${out}
+      npm audit --audit-level=high --json > ${ShellUtils.shellQuote(out)}
     """
   }
 }

--- a/vars/retireJsScan.groovy
+++ b/vars/retireJsScan.groovy
@@ -1,8 +1,16 @@
-def call(Map cfg = [:]) { runWithCatch('retire.js scan Dependency') {
-  String out = cfg.output ?: 'report/retire-report.json'
+import org.jenkinsci.nodesec.ShellUtils
+
+def call(Map cfg = [:]) {
+  runWithCatch('retire.js scan Dependency') {
+    String out = cfg.output ?: 'report/retire-report.json'
+
+    String outputDir = ShellUtils.parentDir(out)
+    if (outputDir) {
+      sh "mkdir -p ${ShellUtils.shellQuote(outputDir)}"
+    }
+
     sh """
-      mkdir -p report
-      retire --severity high --path . --outputformat json --outputpath ${out}
+      retire --severity high --path . --outputformat json --outputpath ${ShellUtils.shellQuote(out)}
     """
   }
 }

--- a/vars/runWithCatch.groovy
+++ b/vars/runWithCatch.groovy
@@ -1,0 +1,14 @@
+def call(String stageName, Closure body) {
+  if (!stageName?.trim()) {
+    error 'Stage name is required for runWithCatch.'
+  }
+  if (body == null) {
+    error 'A body closure is required for runWithCatch.'
+  }
+
+  stage(stageName) {
+    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+      body()
+    }
+  }
+}

--- a/vars/semgrepScan.groovy
+++ b/vars/semgrepScan.groovy
@@ -1,17 +1,25 @@
-def call(Map cfg = [:]) { runWithCatch('Semgrep scan') {
-  String out = cfg.output ?: 'report/semgrep-report.json'
+import org.jenkinsci.nodesec.ShellUtils
+
+def call(Map cfg = [:]) {
+  runWithCatch('Semgrep scan') {
+    String out = cfg.output ?: 'report/semgrep-report.json'
+
+    String outputDir = ShellUtils.parentDir(out)
+    if (outputDir) {
+      sh "mkdir -p ${ShellUtils.shellQuote(outputDir)}"
+    }
+
     sh """
-      mkdir -p report
-      semgrep scan \
-      --config p/owasp-top-ten \
-      --config p/security-audit \
-      --config p/secrets \
-      --config p/javascript \
-      --metrics=off \
-      --exclude node_modules --exclude dist --exclude build --exclude coverage --exclude .git \
-      --timeout 10 \
-      --error \
-      --json --json-output=${out}
+      semgrep scan \\
+      --config p/owasp-top-ten \\
+      --config p/security-audit \\
+      --config p/secrets \\
+      --config p/javascript \\
+      --metrics=off \\
+      --exclude node_modules --exclude dist --exclude build --exclude coverage --exclude .git \\
+      --timeout 10 \\
+      --error \\
+      --json --json-output=${ShellUtils.shellQuote(out)}
     """
-  } 
+  }
 }

--- a/vars/snykCodeScan.groovy
+++ b/vars/snykCodeScan.groovy
@@ -1,9 +1,17 @@
-def call(Map cfg = [:]) { runWithCatch('Snyk Scan Source code') {
-  String out = cfg.output ?: 'report/snyk-code.json'
+import org.jenkinsci.nodesec.ShellUtils
+
+def call(Map cfg = [:]) {
+  runWithCatch('Snyk Scan Source code') {
+    String out = cfg.output ?: 'report/snyk-code.json'
+
+    String outputDir = ShellUtils.parentDir(out)
+    if (outputDir) {
+      sh "mkdir -p ${ShellUtils.shellQuote(outputDir)}"
+    }
+
     withCredentials([string(credentialsId: cfg.tokenCredId ?: 'snyk', variable: 'SNYK_TOKEN')]) {
       sh """
-        mkdir -p report
-        snyk code test --severity-threshold=high --json-file-output=${out}
+        snyk code test --severity-threshold=high --json-file-output=${ShellUtils.shellQuote(out)}
       """
     }
   }

--- a/vars/snykImageScan.groovy
+++ b/vars/snykImageScan.groovy
@@ -1,10 +1,12 @@
 def call(Map cfg = [:]) { runWithCatch('Snyk scan image') {
   String out = cfg.output ?: 'report/snyk-image.json'
   String dockerfile = cfg.dockerfile ?: 'Dockerfile'
+  String awkFile = '.jenkins-awk-extract-image.awk'
+  writeFile file: awkFile, text: libraryResource('utils/awk-extract-image.awk')
   withCredentials([string(credentialsId: cfg.tokenCredId ?: 'snyk', variable: 'SNYK_TOKEN')]) {
       sh """
         mkdir -p report
-        dockerImageName=\$( ${libraryResource 'utils/awk-extract-image.awk'} ${dockerfile} )
+        dockerImageName=\$(awk -f ${awkFile} ${dockerfile})
         snyk container test --severity-threshold=high --json-file-output=${out} \${dockerImageName}
       """
     }

--- a/vars/snykImageScan.groovy
+++ b/vars/snykImageScan.groovy
@@ -1,14 +1,27 @@
-def call(Map cfg = [:]) { runWithCatch('Snyk scan image') {
-  String out = cfg.output ?: 'report/snyk-image.json'
-  String dockerfile = cfg.dockerfile ?: 'Dockerfile'
-  String awkFile = '.jenkins-awk-extract-image.awk'
-  writeFile file: awkFile, text: libraryResource('utils/awk-extract-image.awk')
-  withCredentials([string(credentialsId: cfg.tokenCredId ?: 'snyk', variable: 'SNYK_TOKEN')]) {
-      sh """
-        mkdir -p report
-        dockerImageName=\$(awk -f ${awkFile} ${dockerfile})
-        snyk container test --severity-threshold=high --json-file-output=${out} \${dockerImageName}
-      """
+import org.jenkinsci.nodesec.ShellUtils
+
+def call(Map cfg = [:]) {
+  runWithCatch('Snyk scan image') {
+    String out = cfg.output ?: 'report/snyk-image.json'
+    String dockerfile = cfg.dockerfile ?: 'Dockerfile'
+    String awkFile = '.jenkins-awk-extract-image.awk'
+
+    String outputDir = ShellUtils.parentDir(out)
+    if (outputDir) {
+      sh "mkdir -p ${ShellUtils.shellQuote(outputDir)}"
+    }
+
+    writeFile file: awkFile, text: libraryResource('utils/awk-extract-image.awk')
+
+    try {
+      withCredentials([string(credentialsId: cfg.tokenCredId ?: 'snyk', variable: 'SNYK_TOKEN')]) {
+        sh """
+          dockerImageName=\$(awk -f ${ShellUtils.shellQuote(awkFile)} ${ShellUtils.shellQuote(dockerfile)})
+          snyk container test --severity-threshold=high --json-file-output=${ShellUtils.shellQuote(out)} "\${dockerImageName}"
+        """
+      }
+    } finally {
+      sh "rm -f ${ShellUtils.shellQuote(awkFile)}"
     }
   }
 }

--- a/vars/snykSca.groovy
+++ b/vars/snykSca.groovy
@@ -1,10 +1,18 @@
-def call(Map cfg = [:]) { runWithCatch('Snyk Scan SCA') {
-  String out = cfg.output ?: 'report/snyk-sca.json'
+import org.jenkinsci.nodesec.ShellUtils
+
+def call(Map cfg = [:]) {
+  runWithCatch('Snyk Scan SCA') {
+    String out = cfg.output ?: 'report/snyk-sca.json'
+
+    String outputDir = ShellUtils.parentDir(out)
+    if (outputDir) {
+      sh "mkdir -p ${ShellUtils.shellQuote(outputDir)}"
+    }
+
     withCredentials([string(credentialsId: cfg.tokenCredId ?: 'snyk', variable: 'SNYK_TOKEN')]) {
       sh """
-        mkdir -p report
-        snyk test --severity-threshold=high --json-file-output=${out}
+        snyk test --severity-threshold=high --json-file-output=${ShellUtils.shellQuote(out)}
       """
     }
-  } 
+  }
 }

--- a/vars/trivyScan.groovy
+++ b/vars/trivyScan.groovy
@@ -1,9 +1,11 @@
 def call(Map cfg = [:]) { runWithCatch('Trivy scan') {
   String out = cfg.output ?: 'report/trivy-report.json'
   String dockerfile = cfg.dockerfile ?: 'Dockerfile'
-    sh """
+  String awkFile = '.jenkins-awk-extract-image.awk'
+  writeFile file: awkFile, text: libraryResource('utils/awk-extract-image.awk')
+  sh """
       mkdir -p report
-      dockerImageName=\$( ${libraryResource 'utils/awk-extract-image.awk'} ${dockerfile} )
+      dockerImageName=\$(awk -f ${awkFile} ${dockerfile})
       trivy image --scanners vuln --severity HIGH,CRITICAL --exit-code 1 --no-progress --quiet -f json -o ${out} \${dockerImageName}
     """
   }

--- a/vars/trivyScan.groovy
+++ b/vars/trivyScan.groovy
@@ -1,12 +1,25 @@
-def call(Map cfg = [:]) { runWithCatch('Trivy scan') {
-  String out = cfg.output ?: 'report/trivy-report.json'
-  String dockerfile = cfg.dockerfile ?: 'Dockerfile'
-  String awkFile = '.jenkins-awk-extract-image.awk'
-  writeFile file: awkFile, text: libraryResource('utils/awk-extract-image.awk')
-  sh """
-      mkdir -p report
-      dockerImageName=\$(awk -f ${awkFile} ${dockerfile})
-      trivy image --scanners vuln --severity HIGH,CRITICAL --exit-code 1 --no-progress --quiet -f json -o ${out} \${dockerImageName}
-    """
+import org.jenkinsci.nodesec.ShellUtils
+
+def call(Map cfg = [:]) {
+  runWithCatch('Trivy scan') {
+    String out = cfg.output ?: 'report/trivy-report.json'
+    String dockerfile = cfg.dockerfile ?: 'Dockerfile'
+    String awkFile = '.jenkins-awk-extract-image.awk'
+
+    String outputDir = ShellUtils.parentDir(out)
+    if (outputDir) {
+      sh "mkdir -p ${ShellUtils.shellQuote(outputDir)}"
+    }
+
+    writeFile file: awkFile, text: libraryResource('utils/awk-extract-image.awk')
+
+    try {
+      sh """
+        dockerImageName=\$(awk -f ${ShellUtils.shellQuote(awkFile)} ${ShellUtils.shellQuote(dockerfile)})
+        trivy image --scanners vuln --severity HIGH,CRITICAL --exit-code 1 --no-progress --quiet -f json -o ${ShellUtils.shellQuote(out)} "\${dockerImageName}"
+      """
+    } finally {
+      sh "rm -f ${ShellUtils.shellQuote(awkFile)}"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a reusable runWithCatch helper to wrap scan stages in catchError
- write the awk helper to disk before invoking snyk and trivy so docker image names are parsed correctly

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68cad41a954c832cb0634e0721c5b75f